### PR TITLE
feat: Add Docset support for searching official API documentation

### DIFF
--- a/DOCSETS.md
+++ b/DOCSETS.md
@@ -1,0 +1,178 @@
+# Docset Support in doc-bot
+
+doc-bot now supports [Docsets](https://kapeli.com/docsets) - the documentation format used by Dash, Zeal, and Velocity. This allows you to search and access official API documentation alongside your project-specific Markdown documentation.
+
+## Overview
+
+Docsets are pre-indexed documentation sets containing HTML documentation with a SQLite search index. doc-bot can:
+- Install docsets from URLs or local files
+- Search across multiple docsets simultaneously
+- Combine docset results with your Markdown documentation
+- Access official documentation for iOS, macOS, Swift, and many other platforms
+
+## Configuration
+
+By default, docsets are stored in `~/Developer/DocSets`. You can customize this location:
+
+```bash
+# Custom docset storage location
+doc-bot --docs ./docs --docsets ~/MyDocSets
+
+# MCP configuration
+{
+  "command": "doc-bot",
+  "args": ["--docs", "./docs", "--docsets", "/custom/path/to/docsets"]
+}
+```
+
+## Available Tools
+
+### Managing Docsets
+
+#### `add_docset`
+Install a new docset from a URL or local file:
+
+```json
+{
+  "source": "https://example.com/iOS.tgz"
+}
+```
+
+Supported formats:
+- `.docset` directories
+- `.tgz` / `.tar.gz` archives
+- `.zip` archives
+
+#### `remove_docset`
+Remove an installed docset:
+
+```json
+{
+  "docsetId": "c8d713b0"
+}
+```
+
+#### `list_docsets`
+List all installed docsets with their metadata.
+
+### Searching Documentation
+
+#### `search_docsets`
+Search only within installed docsets:
+
+```json
+{
+  "query": "UIViewController",
+  "type": "Class",        // Optional: filter by type
+  "docsetId": "ios",      // Optional: search specific docset
+  "limit": 50             // Optional: max results (default: 50)
+}
+```
+
+Supported types:
+- `Class`, `Method`, `Function`, `Property`
+- `Protocol`, `Enum`, `Structure`
+- `Guide`, `Sample`, `Category`
+- `Constant`, `Variable`, `Typedef`, `Macro`
+
+#### `search_all`
+Search both Markdown documentation and docsets:
+
+```json
+{
+  "query": "authentication"
+}
+```
+
+Returns results from both sources, clearly labeled.
+
+#### `docset_stats`
+Get statistics about installed docsets:
+- Entry counts by type
+- Total documentation entries
+- Storage information
+
+## Example Workflow
+
+1. **Install iOS Documentation**
+   ```
+   add_docset: { "source": "https://dash-docsets.com/iOS.tgz" }
+   ```
+
+2. **Search for UIViewController**
+   ```
+   search_docsets: { "query": "UIViewController", "type": "Class" }
+   ```
+
+3. **Get Combined Results**
+   ```
+   search_all: { "query": "view lifecycle" }
+   ```
+   Returns both your custom docs about view lifecycle AND official Apple documentation.
+
+## Where to Find Docsets
+
+### Official Sources
+- [Dash User Contributed Docsets](https://github.com/Kapeli/Dash-User-Contributions)
+- [Zeal Feed](https://zealusercontributions.herokuapp.com/)
+
+### Popular Docsets
+- iOS: `https://dash-docsets.com/iOS.tgz`
+- macOS: `https://dash-docsets.com/macOS.tgz`
+- Swift: `https://dash-docsets.com/Swift.tgz`
+- JavaScript: `https://dash-docsets.com/JavaScript.tgz`
+- React: `https://dash-docsets.com/React.tgz`
+
+## Storage Structure
+
+Docsets are stored in a structured format:
+
+```
+~/Developer/DocSets/
+├── docsets.json              # Metadata for all docsets
+├── c8d713b0/                 # Unique ID directory
+│   └── iOS.docset/           # Actual docset
+│       ├── Contents/
+│       │   ├── Info.plist    # Docset metadata
+│       │   └── Resources/
+│       │       ├── docSet.dsidx     # SQLite index
+│       │       └── Documents/       # HTML documentation
+└── a5f2c891/
+    └── Swift.docset/
+```
+
+## Integration with AI Agents
+
+When using doc-bot with AI agents (like Claude), the docset tools provide:
+- Access to official API documentation
+- Accurate class/method signatures
+- Framework-specific guidance
+- Code examples from official sources
+
+This complements your project-specific documentation, giving AI agents both:
+- Your custom implementation patterns (Markdown docs)
+- Official API references (Docsets)
+
+## Performance Considerations
+
+- Docsets can be large (100MB-1GB+)
+- Initial download may take time depending on connection
+- Searches are fast due to SQLite indexing
+- Multiple docsets can be searched simultaneously
+
+## Troubleshooting
+
+### Docset Won't Install
+- Check the source URL is accessible
+- Ensure sufficient disk space
+- Verify the file is a valid docset format
+
+### Search Returns No Results
+- Verify docsets are installed with `list_docsets`
+- Check the search query syntax
+- Try searching without filters first
+
+### Storage Issues
+- Default location requires `~/Developer/DocSets` to be writable
+- Use `--docsets` flag to specify alternate location
+- Each docset is stored in a unique subdirectory

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ doc-bot is an intelligent documentation server that:
 - 🧠 **Auto-indexes** content for smart inference, based on metadata and keywords
 - 🤖 **Provides agentic tools** to query, and update your documentation
 - 🔄 **Updates** automatically when docs change
+- 📚 **Supports Docsets** for searching official API documentation alongside your custom docs
 
 ## Why MCP Instead of Static Rules?
 
@@ -108,6 +109,18 @@ IDE's use static rule files (like Cursor Rules or Copilot's .github/copilot-inst
        "doc-bot": {
          "command": "npx",
          "args": ["@afterxleep/doc-bot@latest", "--docs", "./my-custom-docs"]
+       }
+     }
+   }
+   ```
+   
+   **With Docsets support (for official API documentation):**
+   ```json
+   {
+     "mcpServers": {
+       "doc-bot": {
+         "command": "npx",
+         "args": ["@afterxleep/doc-bot@latest", "--docs", "./docs", "--docsets", "~/MyDocSets"]
        }
      }
    }
@@ -385,6 +398,23 @@ git commit -m "feat: your feature description"
 git push origin main
 git push --tags  # Push version tags
 ```
+
+## Docset Support
+
+doc-bot now supports [Docsets](https://kapeli.com/docsets) - pre-indexed documentation used by Dash, Zeal, and Velocity. This allows you to search official API documentation alongside your custom project docs.
+
+### Key Features
+- Search iOS, macOS, Swift, and other official documentation
+- Install docsets from URLs or local files
+- Unified search across both custom docs and official APIs
+- No manual HTML parsing required
+
+### Quick Start
+1. **Install a docset**: Use the `add_docset` tool with a URL or local path
+2. **Search documentation**: Use `search_docsets` for docsets only, or `search_all` for unified results
+3. **Manage docsets**: List installed docsets with `list_docsets`, remove with `remove_docset`
+
+See [DOCSETS.md](./DOCSETS.md) for detailed documentation.
 
 ## License
 

--- a/bin/doc-bot.js
+++ b/bin/doc-bot.js
@@ -2,6 +2,7 @@
 
 import { program } from 'commander';
 import path from 'path';
+import os from 'os';
 import fs from 'fs-extra';
 import { DocsServer } from '../src/index.js';
 import { readFileSync } from 'fs';
@@ -17,6 +18,7 @@ program
   .description('Generic MCP server for intelligent documentation access')
   .version(packageJson.version)
   .option('-d, --docs <path>', 'Path to docs folder', 'doc-bot')
+  .option('--docsets <path>', 'Path to docsets folder', path.join(os.homedir(), 'Developer', 'DocSets'))
   .option('-v, --verbose', 'Enable verbose logging')
   .option('-w, --watch', 'Watch for file changes')
   .parse();
@@ -25,6 +27,7 @@ const options = program.opts();
 
 async function main() {
   const docsPath = path.resolve(options.docs);
+  const docsetsPath = path.resolve(options.docsets);
   
   // Check if documentation folder exists
   if (!await fs.pathExists(docsPath)) {
@@ -46,6 +49,7 @@ async function main() {
   
   const server = new DocsServer({
     docsPath,
+    docsetsPath,
     verbose: options.verbose,
     watch: options.watch
   });
@@ -53,6 +57,7 @@ async function main() {
   if (options.verbose) {
     console.error('🚀 Starting doc-bot...');
     console.error(`📁 Documentation: ${docsPath}`);
+    console.error(`📚 Docsets: ${docsetsPath}`);
     console.error(`⚙️  Configuration: Frontmatter-based`);
     
     if (options.watch) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,24 @@
 {
   "name": "@afterxleep/doc-bot",
-  "version": "1.8.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afterxleep/doc-bot",
-      "version": "1.8.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^0.7.0",
+        "adm-zip": "^0.5.10",
+        "axios": "^1.6.5",
+        "better-sqlite3": "^11.2.1",
         "chokidar": "^3.5.3",
         "commander": "^12.0.0",
         "fs-extra": "^11.0.0",
         "glob": "^10.3.0",
+        "plist": "^3.1.0",
+        "tar": "^6.2.0",
         "yaml": "^2.3.0"
       },
       "bin": {
@@ -1385,6 +1390,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1406,6 +1420,15 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {
@@ -1509,8 +1532,18 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
+      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -1634,6 +1667,37 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -1644,6 +1708,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -1712,6 +1796,30 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1732,7 +1840,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -1849,6 +1956,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/ci-info": {
@@ -1969,7 +2085,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2081,6 +2196,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
@@ -2094,6 +2224,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -2117,7 +2256,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2130,6 +2268,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
+      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -2180,7 +2327,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2223,6 +2369,15 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -2237,7 +2392,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2247,7 +2401,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2257,7 +2410,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2270,7 +2422,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2523,6 +2674,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -2601,6 +2761,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2652,6 +2818,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2672,7 +2858,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
       "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -2701,6 +2886,12 @@
         "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
+    },
     "node_modules/fs-extra": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
@@ -2714,6 +2905,36 @@
       "engines": {
         "node": ">=14.14"
       }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-minipass/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -2740,7 +2961,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2770,7 +2990,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2805,7 +3024,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -2827,6 +3045,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "10.4.5",
@@ -2904,7 +3128,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2940,7 +3163,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2953,7 +3175,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -2969,7 +3190,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3022,6 +3242,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3096,6 +3336,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/is-arrayish": {
@@ -4163,7 +4409,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4217,7 +4462,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4227,7 +4471,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -4246,6 +4489,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -4259,6 +4514,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -4268,11 +4532,66 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -4281,6 +4600,30 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.75.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
+      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4335,7 +4678,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -4611,6 +4953,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/plist": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.0.tgz",
+      "integrity": "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4661,6 +5043,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -4742,12 +5140,50 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -4909,6 +5345,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5040,6 +5496,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -5115,6 +5616,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-length": {
@@ -5330,6 +5840,72 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
+      "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -5400,6 +5976,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-check": {
@@ -5503,6 +6091,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -5652,7 +6246,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -5675,6 +6268,15 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,12 @@
     "chokidar": "^3.5.3",
     "fs-extra": "^11.0.0",
     "glob": "^10.3.0",
-    "yaml": "^2.3.0"
+    "yaml": "^2.3.0",
+    "better-sqlite3": "^11.2.1",
+    "axios": "^1.6.5",
+    "tar": "^6.2.0",
+    "plist": "^3.1.0",
+    "adm-zip": "^0.5.10"
   },
   "devDependencies": {
     "eslint": "^8.57.0",

--- a/src/__tests__/docset-integration.test.js
+++ b/src/__tests__/docset-integration.test.js
@@ -1,0 +1,146 @@
+import { DocsServer } from '../index.js';
+import fs from 'fs-extra';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import os from 'os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('DocsServer Docset Integration', () => {
+  let server;
+  let tempDocsPath;
+  let tempDocsetsPath;
+
+  beforeEach(async () => {
+    // Create temporary directories
+    tempDocsPath = path.join(__dirname, 'temp-docs-' + Date.now());
+    tempDocsetsPath = path.join(__dirname, 'temp-docsets-' + Date.now());
+    
+    await fs.ensureDir(tempDocsPath);
+    await fs.ensureDir(tempDocsetsPath);
+    
+    // Create a simple test doc
+    await fs.writeFile(
+      path.join(tempDocsPath, 'test.md'),
+      '---\nalwaysApply: true\ntitle: Test Doc\n---\n# Test'
+    );
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+    }
+    await fs.remove(tempDocsPath);
+    await fs.remove(tempDocsetsPath);
+  });
+
+  describe('Server initialization with docsets', () => {
+    it('should initialize with custom docsets path', async () => {
+      server = new DocsServer({
+        docsPath: tempDocsPath,
+        docsetsPath: tempDocsetsPath,
+        verbose: false
+      });
+
+      await server.start();
+      
+      expect(server.docsetService).toBeDefined();
+      expect(server.docsetService.storagePath).toBe(tempDocsetsPath);
+    });
+
+    it('should use default docsets path when not provided', async () => {
+      server = new DocsServer({
+        docsPath: tempDocsPath,
+        verbose: false
+      });
+
+      await server.start();
+      
+      const expectedPath = path.join(os.homedir(), 'Developer', 'DocSets');
+      expect(server.docsetService.storagePath).toBe(expectedPath);
+    });
+  });
+
+  describe('Docset service functionality', () => {
+    beforeEach(async () => {
+      server = new DocsServer({
+        docsPath: tempDocsPath,
+        docsetsPath: tempDocsetsPath,
+        verbose: false
+      });
+      await server.start();
+    });
+
+    it('should have docset service initialized', () => {
+      expect(server.docsetService).toBeDefined();
+      expect(server.docsetDatabase).toBeDefined();
+    });
+
+    it('should have empty docsets initially', async () => {
+      const docsets = await server.docsetService.listDocsets();
+      expect(docsets).toEqual([]);
+    });
+
+    it('should handle docset operations', async () => {
+      // Create a mock docset
+      const mockDocsetPath = path.join(tempDocsetsPath, 'Mock.docset');
+      const contentsPath = path.join(mockDocsetPath, 'Contents');
+      const resourcesPath = path.join(contentsPath, 'Resources');
+      
+      await fs.ensureDir(resourcesPath);
+      
+      // Create Info.plist
+      const infoPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>Mock Documentation</string>
+  <key>CFBundleIdentifier</key>
+  <string>mock.documentation</string>
+</dict>
+</plist>`;
+      await fs.writeFile(path.join(contentsPath, 'Info.plist'), infoPlist);
+      
+      // Create SQLite database
+      const Database = (await import('better-sqlite3')).default;
+      const dbPath = path.join(resourcesPath, 'docSet.dsidx');
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE searchIndex(
+          id INTEGER PRIMARY KEY,
+          name TEXT,
+          type TEXT,
+          path TEXT
+        );
+      `);
+      db.prepare('INSERT INTO searchIndex (name, type, path) VALUES (?, ?, ?)')
+        .run('TestClass', 'Class', 'test.html');
+      db.close();
+      
+      // Test adding docset
+      const docsetInfo = await server.docsetService.addDocset(mockDocsetPath);
+      expect(docsetInfo.name).toBe('Mock Documentation');
+      
+      // Test listing docsets
+      const docsets = await server.docsetService.listDocsets();
+      expect(docsets).toHaveLength(1);
+      expect(docsets[0].name).toBe('Mock Documentation');
+      
+      // Add to database for searching
+      server.docsetDatabase.addDocset(docsetInfo);
+      
+      // Test searching
+      const searchResults = server.docsetDatabase.search('Test');
+      expect(searchResults).toHaveLength(1);
+      expect(searchResults[0].name).toBe('TestClass');
+      
+      // Test removing docset
+      await server.docsetService.removeDocset(docsetInfo.id);
+      const finalDocsets = await server.docsetService.listDocsets();
+      expect(finalDocsets).toHaveLength(0);
+    });
+  });
+});

--- a/src/services/docset/__tests__/DocsetDatabase.test.js
+++ b/src/services/docset/__tests__/DocsetDatabase.test.js
@@ -1,0 +1,337 @@
+import { DocsetDatabase, MultiDocsetDatabase } from '../database.js';
+import Database from 'better-sqlite3';
+import fs from 'fs-extra';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('DocsetDatabase', () => {
+  let tempDir;
+  let testDbPath;
+  let testDb;
+  let docsetInfo;
+
+  beforeEach(async () => {
+    // Create temporary directory and test database
+    tempDir = path.join(__dirname, 'temp-db-' + Date.now());
+    await fs.ensureDir(tempDir);
+    
+    // Create docset structure
+    const docsetPath = path.join(tempDir, 'Test.docset');
+    const resourcesPath = path.join(docsetPath, 'Contents', 'Resources');
+    await fs.ensureDir(resourcesPath);
+    
+    testDbPath = path.join(resourcesPath, 'docSet.dsidx');
+    
+    // Create test SQLite database with docset schema
+    testDb = new Database(testDbPath);
+    testDb.exec(`
+      CREATE TABLE searchIndex(
+        id INTEGER PRIMARY KEY,
+        name TEXT,
+        type TEXT,
+        path TEXT
+      );
+      CREATE UNIQUE INDEX anchor ON searchIndex (name, type, path);
+    `);
+    
+    // Insert test data
+    const insertStmt = testDb.prepare('INSERT INTO searchIndex (name, type, path) VALUES (?, ?, ?)');
+    insertStmt.run('UIViewController', 'Class', 'UIKit/UIViewController.html');
+    insertStmt.run('viewDidLoad', 'Method', 'UIKit/UIViewController.html#viewDidLoad');
+    insertStmt.run('NSString', 'Class', 'Foundation/NSString.html');
+    insertStmt.run('stringWithFormat:', 'Method', 'Foundation/NSString.html#stringWithFormat');
+    insertStmt.run('iOS App Lifecycle', 'Guide', 'Guides/AppLifecycle.html');
+    testDb.close();
+    
+    // Create docset info
+    docsetInfo = {
+      id: 'test-docset',
+      name: 'Test Docset',
+      path: docsetPath
+    };
+  });
+
+  afterEach(async () => {
+    // Clean up
+    await fs.remove(tempDir);
+  });
+
+  describe('constructor', () => {
+    it('should open database in readonly mode', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      expect(docsetDb.docsetInfo).toEqual(docsetInfo);
+      expect(docsetDb.db.readonly).toBe(true);
+      docsetDb.close();
+    });
+  });
+
+  describe('search', () => {
+    it('should search by query with case-insensitive matching', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      
+      const results = docsetDb.search('view');
+      expect(results).toHaveLength(2);
+      expect(results[0].name).toBe('viewDidLoad');
+      expect(results[1].name).toBe('UIViewController');
+      
+      docsetDb.close();
+    });
+
+    it('should filter by type when provided', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      
+      const results = docsetDb.search('i', 'Class');
+      expect(results).toHaveLength(2); // UIViewController and NSString
+      expect(results.every(r => r.type === 'Class')).toBe(true);
+      
+      docsetDb.close();
+    });
+
+    it('should respect limit parameter', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      
+      const results = docsetDb.search('i', null, 2);
+      expect(results).toHaveLength(2);
+      
+      docsetDb.close();
+    });
+
+    it('should include docset metadata in results', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      
+      const results = docsetDb.search('UIViewController');
+      expect(results[0]).toMatchObject({
+        name: 'UIViewController',
+        type: 'Class',
+        url: 'UIKit/UIViewController.html',
+        docsetId: 'test-docset',
+        docsetName: 'Test Docset'
+      });
+      
+      docsetDb.close();
+    });
+  });
+
+  describe('searchExact', () => {
+    it('should find exact name match', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      
+      const result = docsetDb.searchExact('UIViewController');
+      expect(result).toMatchObject({
+        name: 'UIViewController',
+        type: 'Class',
+        url: 'UIKit/UIViewController.html'
+      });
+      
+      docsetDb.close();
+    });
+
+    it('should return null when no exact match found', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      
+      const result = docsetDb.searchExact('NonExistent');
+      expect(result).toBeNull();
+      
+      docsetDb.close();
+    });
+
+    it('should filter by type when provided', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      
+      // Should not find UIViewController when searching for Method type
+      const result = docsetDb.searchExact('UIViewController', 'Method');
+      expect(result).toBeNull();
+      
+      docsetDb.close();
+    });
+  });
+
+  describe('statistics methods', () => {
+    it('should get all unique types', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      
+      const types = docsetDb.getTypes();
+      expect(types).toEqual(['Class', 'Guide', 'Method']);
+      
+      docsetDb.close();
+    });
+
+    it('should count entries by type', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      
+      expect(docsetDb.getTypeCount('Class')).toBe(2);
+      expect(docsetDb.getTypeCount('Method')).toBe(2);
+      expect(docsetDb.getTypeCount('Guide')).toBe(1);
+      
+      docsetDb.close();
+    });
+
+    it('should get total entry count', () => {
+      const docsetDb = new DocsetDatabase(docsetInfo);
+      
+      expect(docsetDb.getEntryCount()).toBe(5);
+      
+      docsetDb.close();
+    });
+  });
+});
+
+describe('MultiDocsetDatabase', () => {
+  let multiDb;
+  let tempDir;
+  let docset1Info;
+  let docset2Info;
+
+  beforeEach(async () => {
+    multiDb = new MultiDocsetDatabase();
+    tempDir = path.join(__dirname, 'temp-multi-' + Date.now());
+    await fs.ensureDir(tempDir);
+    
+    // Create two test docsets
+    const createDocset = async (name, entries) => {
+      const docsetPath = path.join(tempDir, `${name}.docset`);
+      const resourcesPath = path.join(docsetPath, 'Contents', 'Resources');
+      await fs.ensureDir(resourcesPath);
+      
+      const dbPath = path.join(resourcesPath, 'docSet.dsidx');
+      const db = new Database(dbPath);
+      db.exec(`
+        CREATE TABLE searchIndex(
+          id INTEGER PRIMARY KEY,
+          name TEXT,
+          type TEXT,
+          path TEXT
+        );
+      `);
+      
+      const insertStmt = db.prepare('INSERT INTO searchIndex (name, type, path) VALUES (?, ?, ?)');
+      entries.forEach(entry => insertStmt.run(entry.name, entry.type, entry.path));
+      db.close();
+      
+      return {
+        id: name.toLowerCase(),
+        name: name,
+        path: docsetPath
+      };
+    };
+    
+    docset1Info = await createDocset('iOS', [
+      { name: 'UIView', type: 'Class', path: 'UIKit/UIView.html' },
+      { name: 'UIViewController', type: 'Class', path: 'UIKit/UIViewController.html' }
+    ]);
+    
+    docset2Info = await createDocset('Swift', [
+      { name: 'Array', type: 'Structure', path: 'Swift/Array.html' },
+      { name: 'String', type: 'Structure', path: 'Swift/String.html' }
+    ]);
+  });
+
+  afterEach(async () => {
+    multiDb.closeAll();
+    await fs.remove(tempDir);
+  });
+
+  describe('docset management', () => {
+    it('should add and remove docsets', () => {
+      multiDb.addDocset(docset1Info);
+      expect(multiDb.databases.size).toBe(1);
+      
+      multiDb.addDocset(docset2Info);
+      expect(multiDb.databases.size).toBe(2);
+      
+      multiDb.removeDocset('ios');
+      expect(multiDb.databases.size).toBe(1);
+      expect(multiDb.databases.has('swift')).toBe(true);
+    });
+
+    it('should replace existing docset when adding with same ID', () => {
+      multiDb.addDocset(docset1Info);
+      const firstDb = multiDb.databases.get('ios');
+      
+      // Add again with same ID
+      multiDb.addDocset(docset1Info);
+      const secondDb = multiDb.databases.get('ios');
+      
+      expect(firstDb).not.toBe(secondDb);
+      expect(multiDb.databases.size).toBe(1);
+    });
+  });
+
+  describe('search across docsets', () => {
+    beforeEach(() => {
+      multiDb.addDocset(docset1Info);
+      multiDb.addDocset(docset2Info);
+    });
+
+    it('should search across all docsets', () => {
+      const results = multiDb.search('i');
+      expect(results).toHaveLength(3); // UIView, UIViewController, String contain 'i'
+      
+      // Check results come from both docsets
+      const docsetIds = [...new Set(results.map(r => r.docsetId))];
+      expect(docsetIds).toHaveLength(2);
+    });
+
+    it('should limit search to specific docset when ID provided', () => {
+      const results = multiDb.search('i', { docsetId: 'ios' });
+      expect(results).toHaveLength(2);
+      expect(results.every(r => r.docsetId === 'ios')).toBe(true);
+    });
+
+    it('should filter by type across all docsets', () => {
+      const results = multiDb.search('', { type: 'Structure' });
+      expect(results).toHaveLength(2);
+      expect(results.every(r => r.type === 'Structure')).toBe(true);
+    });
+
+    it('should respect global limit', () => {
+      const results = multiDb.search('', { limit: 3 });
+      expect(results).toHaveLength(3);
+    });
+  });
+
+  describe('exact search', () => {
+    beforeEach(() => {
+      multiDb.addDocset(docset1Info);
+      multiDb.addDocset(docset2Info);
+    });
+
+    it('should find exact match across all docsets', () => {
+      const result = multiDb.searchExact('Array');
+      expect(result).toMatchObject({
+        name: 'Array',
+        type: 'Structure',
+        docsetId: 'swift'
+      });
+    });
+
+    it('should limit to specific docset when ID provided', () => {
+      const result = multiDb.searchExact('Array', { docsetId: 'ios' });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('statistics', () => {
+    beforeEach(() => {
+      multiDb.addDocset(docset1Info);
+      multiDb.addDocset(docset2Info);
+    });
+
+    it('should get stats for all docsets', () => {
+      const stats = multiDb.getStats();
+      expect(stats).toHaveLength(2);
+      
+      const iosStats = stats.find(s => s.docsetId === 'ios');
+      expect(iosStats.entryCount).toBe(2);
+      expect(iosStats.types).toEqual({ Class: 2 });
+      
+      const swiftStats = stats.find(s => s.docsetId === 'swift');
+      expect(swiftStats.entryCount).toBe(2);
+      expect(swiftStats.types).toEqual({ Structure: 2 });
+    });
+  });
+});

--- a/src/services/docset/__tests__/DocsetService.test.js
+++ b/src/services/docset/__tests__/DocsetService.test.js
@@ -1,0 +1,195 @@
+import { DocsetService } from '../index.js';
+import fs from 'fs-extra';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import os from 'os';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe('DocsetService', () => {
+  let docsetService;
+  let tempStoragePath;
+
+  beforeEach(async () => {
+    // Create a temporary directory for test docsets
+    tempStoragePath = path.join(__dirname, 'temp-docsets-' + Date.now());
+    await fs.ensureDir(tempStoragePath);
+    
+    docsetService = new DocsetService(tempStoragePath);
+  });
+
+  afterEach(async () => {
+    // Clean up temporary directory
+    await fs.remove(tempStoragePath);
+  });
+
+  describe('constructor', () => {
+    it('should create instance with custom storage path', () => {
+      expect(docsetService.storagePath).toBe(tempStoragePath);
+      expect(docsetService.metadataPath).toBe(path.join(tempStoragePath, 'docsets.json'));
+    });
+
+    it('should create instance with default storage path when none provided', () => {
+      const defaultService = new DocsetService();
+      const expectedPath = path.join(os.homedir(), 'Developer', 'DocSets');
+      expect(defaultService.storagePath).toBe(expectedPath);
+    });
+  });
+
+  describe('initialize', () => {
+    it('should create storage directory if it does not exist', async () => {
+      // Remove the directory first
+      await fs.remove(tempStoragePath);
+      expect(await fs.pathExists(tempStoragePath)).toBe(false);
+      
+      // Initialize should create it
+      await docsetService.initialize();
+      expect(await fs.pathExists(tempStoragePath)).toBe(true);
+    });
+
+    it('should load existing metadata on initialization', async () => {
+      // Create test metadata
+      const testMetadata = [
+        {
+          id: 'test-docset-1',
+          name: 'Test Docset',
+          downloadedAt: new Date().toISOString()
+        }
+      ];
+      await fs.writeJson(docsetService.metadataPath, testMetadata);
+      
+      // Create the docset directory
+      await fs.ensureDir(path.join(tempStoragePath, 'test-docset-1'));
+      
+      // Initialize and check if metadata is loaded
+      await docsetService.initialize();
+      expect(docsetService.docsets.size).toBe(1);
+      expect(docsetService.docsets.has('test-docset-1')).toBe(true);
+    });
+
+    it('should skip docsets that no longer exist on disk', async () => {
+      // Create metadata for non-existent docset
+      const testMetadata = [
+        {
+          id: 'missing-docset',
+          name: 'Missing Docset',
+          downloadedAt: new Date().toISOString()
+        }
+      ];
+      await fs.writeJson(docsetService.metadataPath, testMetadata);
+      
+      // Initialize and check that missing docset is not loaded
+      await docsetService.initialize();
+      expect(docsetService.docsets.size).toBe(0);
+    });
+  });
+
+  describe('listDocsets', () => {
+    it('should return empty array when no docsets are installed', async () => {
+      await docsetService.initialize();
+      const docsets = await docsetService.listDocsets();
+      expect(docsets).toEqual([]);
+    });
+
+    it('should return list of installed docsets', async () => {
+      // Add test docsets to internal map
+      docsetService.docsets.set('test-1', { 
+        id: 'test-1', 
+        name: 'Test Docset 1',
+        downloadedAt: new Date()
+      });
+      docsetService.docsets.set('test-2', { 
+        id: 'test-2', 
+        name: 'Test Docset 2',
+        downloadedAt: new Date()
+      });
+      
+      const docsets = await docsetService.listDocsets();
+      expect(docsets).toHaveLength(2);
+      expect(docsets[0].name).toBe('Test Docset 1');
+      expect(docsets[1].name).toBe('Test Docset 2');
+    });
+  });
+
+  describe('getDocset', () => {
+    it('should return docset by ID', () => {
+      const testDocset = { 
+        id: 'test-docset', 
+        name: 'Test Docset',
+        downloadedAt: new Date()
+      };
+      docsetService.docsets.set('test-docset', testDocset);
+      
+      const result = docsetService.getDocset('test-docset');
+      expect(result).toEqual(testDocset);
+    });
+
+    it('should return undefined for non-existent docset', () => {
+      const result = docsetService.getDocset('non-existent');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('removeDocset', () => {
+    it('should throw error when docset does not exist', async () => {
+      await expect(docsetService.removeDocset('non-existent'))
+        .rejects.toThrow('Docset non-existent not found');
+    });
+
+    it('should remove docset directory and metadata', async () => {
+      // Create a test docset
+      const docsetId = 'test-remove';
+      const docsetPath = path.join(tempStoragePath, docsetId, 'Test.docset');
+      await fs.ensureDir(docsetPath);
+      
+      docsetService.docsets.set(docsetId, {
+        id: docsetId,
+        name: 'Test Docset',
+        path: docsetPath,
+        downloadedAt: new Date()
+      });
+      await docsetService.saveMetadata();
+      
+      // Remove the docset
+      await docsetService.removeDocset(docsetId);
+      
+      // Check that directory is removed
+      expect(await fs.pathExists(path.join(tempStoragePath, docsetId))).toBe(false);
+      
+      // Check that metadata is updated
+      expect(docsetService.docsets.has(docsetId)).toBe(false);
+      
+      // Check that metadata file is updated
+      const metadata = await fs.readJson(docsetService.metadataPath);
+      expect(metadata).toHaveLength(0);
+    });
+  });
+
+  describe('download progress tracking', () => {
+    it('should track download progress for a docset', () => {
+      const docsetId = 'test-download';
+      const progress = {
+        docsetId,
+        url: 'https://example.com/test.docset',
+        percentage: 50
+      };
+      
+      docsetService.downloadProgress.set(docsetId, progress);
+      
+      const result = docsetService.getDownloadProgress(docsetId);
+      expect(result).toEqual(progress);
+    });
+
+    it('should return all download progress', () => {
+      docsetService.downloadProgress.set('download-1', { percentage: 25 });
+      docsetService.downloadProgress.set('download-2', { percentage: 75 });
+      
+      const allProgress = docsetService.getAllDownloadProgress();
+      expect(allProgress).toHaveLength(2);
+      expect(allProgress[0].percentage).toBe(25);
+      expect(allProgress[1].percentage).toBe(75);
+    });
+  });
+});

--- a/src/services/docset/database.js
+++ b/src/services/docset/database.js
@@ -1,0 +1,203 @@
+import Database from 'better-sqlite3';
+import path from 'path';
+
+/**
+ * Handles SQLite database operations for a single docset
+ */
+export class DocsetDatabase {
+  constructor(docsetInfo) {
+    this.docsetInfo = docsetInfo;
+    const dbPath = path.join(docsetInfo.path, 'Contents', 'Resources', 'docSet.dsidx');
+    this.db = new Database(dbPath, { readonly: true });
+  }
+
+  search(query, type, limit = 50) {
+    let sql = 'SELECT name, type, path FROM searchIndex WHERE name LIKE ?';
+    const params = [`%${query}%`];
+    
+    if (type) {
+      sql += ' AND type = ?';
+      params.push(type);
+    }
+    
+    sql += ' ORDER BY LENGTH(name), name LIMIT ?';
+    params.push(limit);
+    
+    const stmt = this.db.prepare(sql);
+    const results = stmt.all(...params);
+    
+    return results.map(entry => ({
+      ...entry,
+      url: entry.path,
+      docsetId: this.docsetInfo.id,
+      docsetName: this.docsetInfo.name
+    }));
+  }
+
+  searchExact(name, type) {
+    let sql = 'SELECT name, type, path FROM searchIndex WHERE name = ?';
+    const params = [name];
+    
+    if (type) {
+      sql += ' AND type = ?';
+      params.push(type);
+    }
+    
+    sql += ' LIMIT 1';
+    
+    const stmt = this.db.prepare(sql);
+    const result = stmt.get(...params);
+    
+    if (!result) return null;
+    
+    return {
+      ...result,
+      url: result.path,
+      docsetId: this.docsetInfo.id,
+      docsetName: this.docsetInfo.name
+    };
+  }
+
+  getTypes() {
+    const stmt = this.db.prepare('SELECT DISTINCT type FROM searchIndex ORDER BY type');
+    const results = stmt.all();
+    return results.map(r => r.type);
+  }
+
+  getTypeCount(type) {
+    const stmt = this.db.prepare('SELECT COUNT(*) as count FROM searchIndex WHERE type = ?');
+    const result = stmt.get(type);
+    return result.count;
+  }
+
+  getEntryCount() {
+    const stmt = this.db.prepare('SELECT COUNT(*) as count FROM searchIndex');
+    const result = stmt.get();
+    return result.count;
+  }
+
+  close() {
+    this.db.close();
+  }
+}
+
+/**
+ * Manages multiple docset databases and provides unified search
+ */
+export class MultiDocsetDatabase {
+  constructor() {
+    this.databases = new Map();
+  }
+
+  addDocset(docsetInfo) {
+    if (this.databases.has(docsetInfo.id)) {
+      this.databases.get(docsetInfo.id).close();
+    }
+    this.databases.set(docsetInfo.id, new DocsetDatabase(docsetInfo));
+  }
+
+  removeDocset(docsetId) {
+    const db = this.databases.get(docsetId);
+    if (db) {
+      db.close();
+      this.databases.delete(docsetId);
+    }
+  }
+
+  search(query, options = {}) {
+    const { type, docsetId, limit = 50 } = options;
+    const results = [];
+
+    // If specific docset is requested
+    if (docsetId) {
+      const db = this.databases.get(docsetId);
+      if (db) {
+        return db.search(query, type, limit);
+      }
+      return [];
+    }
+
+    // Search across all docsets
+    const limitPerDocset = Math.ceil(limit / Math.max(1, this.databases.size));
+    
+    for (const db of this.databases.values()) {
+      const docsetResults = db.search(query, type, limitPerDocset);
+      results.push(...docsetResults);
+    }
+
+    // Sort by name length and then alphabetically
+    results.sort((a, b) => {
+      const lengthDiff = a.name.length - b.name.length;
+      if (lengthDiff !== 0) return lengthDiff;
+      return a.name.localeCompare(b.name);
+    });
+
+    return results.slice(0, limit);
+  }
+
+  searchExact(name, options = {}) {
+    const { type, docsetId } = options;
+
+    // If specific docset is requested
+    if (docsetId) {
+      const db = this.databases.get(docsetId);
+      if (db) {
+        return db.searchExact(name, type);
+      }
+      return null;
+    }
+
+    // Search across all docsets, return first match
+    for (const db of this.databases.values()) {
+      const result = db.searchExact(name, type);
+      if (result) return result;
+    }
+
+    return null;
+  }
+
+  getAllTypes() {
+    const results = [];
+    
+    for (const [docsetId, db] of this.databases) {
+      const docsetInfo = db.docsetInfo;
+      results.push({
+        docsetId,
+        docsetName: docsetInfo.name,
+        types: db.getTypes()
+      });
+    }
+
+    return results;
+  }
+
+  getStats() {
+    const results = [];
+    
+    for (const [docsetId, db] of this.databases) {
+      const docsetInfo = db.docsetInfo;
+      const types = db.getTypes();
+      const typeStats = {};
+      
+      for (const type of types) {
+        typeStats[type] = db.getTypeCount(type);
+      }
+
+      results.push({
+        docsetId,
+        docsetName: docsetInfo.name,
+        entryCount: db.getEntryCount(),
+        types: typeStats
+      });
+    }
+
+    return results;
+  }
+
+  closeAll() {
+    for (const db of this.databases.values()) {
+      db.close();
+    }
+    this.databases.clear();
+  }
+}

--- a/src/services/docset/index.js
+++ b/src/services/docset/index.js
@@ -1,0 +1,349 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { createWriteStream } from 'fs';
+import axios from 'axios';
+import tar from 'tar';
+import AdmZip from 'adm-zip';
+import plist from 'plist';
+import crypto from 'crypto';
+import { pipeline } from 'stream/promises';
+import os from 'os';
+
+/**
+ * Manages docset storage, downloading, and metadata for doc-bot
+ * Adapted from scout server's DocsetManager
+ */
+export class DocsetService {
+  constructor(storagePath) {
+    this.storagePath = storagePath || path.join(os.homedir(), 'Developer', 'DocSets');
+    this.metadataPath = path.join(this.storagePath, 'docsets.json');
+    this.docsets = new Map();
+    this.downloadProgress = new Map();
+  }
+
+  async initialize() {
+    // Create storage directory if it doesn't exist
+    await fs.ensureDir(this.storagePath);
+    
+    // Load existing docsets metadata
+    await this.loadMetadata();
+  }
+
+  async loadMetadata() {
+    try {
+      if (await fs.pathExists(this.metadataPath)) {
+        const data = await fs.readJson(this.metadataPath);
+        
+        for (const docset of data) {
+          // Verify docset still exists
+          const docsetPath = path.join(this.storagePath, docset.id);
+          if (await fs.pathExists(docsetPath)) {
+            this.docsets.set(docset.id, {
+              ...docset,
+              downloadedAt: new Date(docset.downloadedAt)
+            });
+          }
+        }
+      }
+    } catch (error) {
+      // If metadata is corrupted, start fresh
+      this.docsets.clear();
+    }
+  }
+
+  async saveMetadata() {
+    const docsets = Array.from(this.docsets.values());
+    await fs.writeJson(this.metadataPath, docsets, { spaces: 2 });
+  }
+
+  async addDocset(source) {
+    // Determine if source is URL or local path
+    const isUrl = source.startsWith('http://') || source.startsWith('https://');
+    const isLocalPath = await this.isLocalPath(source);
+    
+    if (!isUrl && !isLocalPath) {
+      throw new Error(`Invalid source: ${source}. Must be a valid URL or local file path.`);
+    }
+
+    // Generate unique ID for the docset
+    const docsetId = crypto.createHash('md5').update(source).digest('hex').substring(0, 8);
+    
+    // Check if already exists
+    if (this.docsets.has(docsetId)) {
+      throw new Error(`Docset from ${source} is already installed`);
+    }
+
+    if (isUrl) {
+      return await this.addDocsetFromUrl(source, docsetId);
+    } else {
+      return await this.addDocsetFromLocal(source, docsetId);
+    }
+  }
+
+  async isLocalPath(source) {
+    try {
+      const stats = await fs.stat(source);
+      return stats.isFile() || stats.isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  async addDocsetFromLocal(localPath, docsetId) {
+    try {
+      const stats = await fs.stat(localPath);
+      const extractPath = path.join(this.storagePath, docsetId);
+      await fs.ensureDir(extractPath);
+
+      let docsetPath;
+
+      if (stats.isDirectory() && localPath.endsWith('.docset')) {
+        // Direct docset directory - copy it
+        docsetPath = path.join(extractPath, path.basename(localPath));
+        await fs.copy(localPath, docsetPath);
+      } else if (stats.isFile()) {
+        // Handle different archive formats
+        if (localPath.endsWith('.tgz') || localPath.endsWith('.tar.gz')) {
+          // Tar archive - extract it
+          await tar.extract({
+            file: localPath,
+            cwd: extractPath,
+            strip: 0
+          });
+        } else if (localPath.endsWith('.zip')) {
+          // ZIP archive - extract it
+          const zip = new AdmZip(localPath);
+          zip.extractAllTo(extractPath, true);
+        } else {
+          throw new Error('Local file must be a .tgz, .tar.gz, or .zip archive');
+        }
+
+        // Find the .docset directory
+        const files = await fs.readdir(extractPath);
+        const docsetDir = files.find(f => f.endsWith('.docset'));
+        
+        if (!docsetDir) {
+          throw new Error('No .docset directory found in the archive');
+        }
+
+        docsetPath = path.join(extractPath, docsetDir);
+      } else {
+        throw new Error('Local path must be a .docset directory or archive file (.tgz, .tar.gz, .zip)');
+      }
+
+      // Read docset metadata
+      const metadata = await this.readDocsetMetadata(docsetPath);
+      
+      // Get docset size
+      const size = await this.getDirectorySize(docsetPath);
+
+      // Create docset info
+      const docsetInfo = {
+        id: docsetId,
+        name: metadata.CFBundleName || path.basename(docsetPath).replace('.docset', ''),
+        source: localPath,
+        path: docsetPath,
+        version: metadata.CFBundleVersion,
+        platform: metadata.DocSetPlatformFamily,
+        downloadedAt: new Date(),
+        size
+      };
+
+      // Save to metadata
+      this.docsets.set(docsetId, docsetInfo);
+      await this.saveMetadata();
+
+      return docsetInfo;
+    } catch (error) {
+      // Clean up on failure
+      try {
+        const extractPath = path.join(this.storagePath, docsetId);
+        await fs.remove(extractPath);
+      } catch (cleanupError) {
+        // Ignore cleanup errors
+      }
+      
+      throw error;
+    }
+  }
+
+  async addDocsetFromUrl(url, docsetId) {
+    const progress = {
+      docsetId,
+      url,
+      totalBytes: 0,
+      downloadedBytes: 0,
+      percentage: 0,
+      status: 'downloading'
+    };
+    
+    this.downloadProgress.set(docsetId, progress);
+
+    try {
+      // Determine file extension from URL
+      const urlLower = url.toLowerCase();
+      let fileExt = '.tgz';
+      if (urlLower.endsWith('.zip')) {
+        fileExt = '.zip';
+      } else if (urlLower.endsWith('.tar.gz')) {
+        fileExt = '.tar.gz';
+      }
+
+      // Download the docset
+      const downloadPath = path.join(this.storagePath, `${docsetId}${fileExt}`);
+      await this.downloadFile(url, downloadPath, docsetId);
+
+      // Update progress
+      progress.status = 'extracting';
+      
+      // Extract the docset
+      const extractPath = path.join(this.storagePath, docsetId);
+      await fs.ensureDir(extractPath);
+      
+      if (fileExt === '.zip') {
+        // Extract ZIP file
+        const zip = new AdmZip(downloadPath);
+        zip.extractAllTo(extractPath, true);
+      } else {
+        // Extract tar archive
+        await tar.extract({
+          file: downloadPath,
+          cwd: extractPath,
+          strip: 0
+        });
+      }
+
+      // Clean up downloaded file
+      await fs.unlink(downloadPath);
+
+      // Find the .docset directory
+      const files = await fs.readdir(extractPath);
+      const docsetDir = files.find(f => f.endsWith('.docset'));
+      
+      if (!docsetDir) {
+        throw new Error('No .docset directory found in the downloaded archive');
+      }
+
+      const docsetPath = path.join(extractPath, docsetDir);
+      
+      // Read docset metadata
+      const metadata = await this.readDocsetMetadata(docsetPath);
+      
+      // Get docset size
+      const size = await this.getDirectorySize(docsetPath);
+
+      // Create docset info
+      const docsetInfo = {
+        id: docsetId,
+        name: metadata.CFBundleName || docsetDir.replace('.docset', ''),
+        source: url,
+        path: docsetPath,
+        version: metadata.CFBundleVersion,
+        platform: metadata.DocSetPlatformFamily,
+        downloadedAt: new Date(),
+        size
+      };
+
+      // Save to metadata
+      this.docsets.set(docsetId, docsetInfo);
+      await this.saveMetadata();
+
+      // Update progress
+      progress.status = 'completed';
+      progress.percentage = 100;
+
+      return docsetInfo;
+    } catch (error) {
+      progress.status = 'failed';
+      progress.error = error.message;
+      
+      // Clean up any partial downloads
+      try {
+        const extractPath = path.join(this.storagePath, docsetId);
+        await fs.remove(extractPath);
+      } catch (cleanupError) {
+        // Ignore cleanup errors
+      }
+      
+      throw error;
+    } finally {
+      // Clean up progress after a delay
+      setTimeout(() => {
+        this.downloadProgress.delete(docsetId);
+      }, 5000);
+    }
+  }
+
+  async downloadFile(url, destination, docsetId) {
+    const response = await axios({
+      method: 'GET',
+      url,
+      responseType: 'stream',
+      onDownloadProgress: (progressEvent) => {
+        const progress = this.downloadProgress.get(docsetId);
+        if (progress && progressEvent.total) {
+          progress.totalBytes = progressEvent.total;
+          progress.downloadedBytes = progressEvent.loaded;
+          progress.percentage = Math.round((progressEvent.loaded / progressEvent.total) * 100);
+        }
+      }
+    });
+
+    const writer = createWriteStream(destination);
+    await pipeline(response.data, writer);
+  }
+
+  async readDocsetMetadata(docsetPath) {
+    const plistPath = path.join(docsetPath, 'Contents', 'Info.plist');
+    const plistContent = await fs.readFile(plistPath, 'utf-8');
+    return plist.parse(plistContent);
+  }
+
+  async getDirectorySize(dirPath) {
+    let size = 0;
+    const files = await fs.readdir(dirPath, { withFileTypes: true });
+    
+    for (const file of files) {
+      const filePath = path.join(dirPath, file.name);
+      if (file.isDirectory()) {
+        size += await this.getDirectorySize(filePath);
+      } else {
+        const stats = await fs.stat(filePath);
+        size += stats.size;
+      }
+    }
+    
+    return size;
+  }
+
+  async removeDocset(docsetId) {
+    const docset = this.docsets.get(docsetId);
+    if (!docset) {
+      throw new Error(`Docset ${docsetId} not found`);
+    }
+
+    // Remove the docset directory
+    const docsetDir = path.dirname(docset.path);
+    await fs.remove(docsetDir);
+
+    // Update metadata
+    this.docsets.delete(docsetId);
+    await this.saveMetadata();
+  }
+
+  async listDocsets() {
+    return Array.from(this.docsets.values());
+  }
+
+  getDocset(docsetId) {
+    return this.docsets.get(docsetId);
+  }
+
+  getDownloadProgress(docsetId) {
+    return this.downloadProgress.get(docsetId);
+  }
+
+  getAllDownloadProgress() {
+    return Array.from(this.downloadProgress.values());
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds support for [Docsets](https://kapeli.com/docsets) - the documentation format used by Dash, Zeal, and Velocity. This allows doc-bot users to search official API documentation alongside their custom project documentation.

## Features Added

### 🔧 Core Implementation
- **DocsetService**: Manages docset installation, removal, and metadata storage
- **DocsetDatabase**: SQLite wrapper for fast searching within docsets
- **MultiDocsetDatabase**: Unified search across multiple installed docsets

### 🛠️ New MCP Tools
- `add_docset` - Install docsets from URLs or local files
- `remove_docset` - Uninstall docsets
- `list_docsets` - Show all installed docsets
- `search_docsets` - Search only within docsets
- `docset_stats` - Get statistics about installed docsets
- `search_all` - Unified search across both Markdown docs and docsets

### 📚 Supported Formats
- Direct `.docset` directories
- `.tgz` / `.tar.gz` archives
- `.zip` archives

### ⚙️ Configuration
- New `--docsets` CLI argument to specify storage location
- Default storage: `~/Developer/DocSets` (outside git repos)
- Docsets are never stored in project directories

## Implementation Details

The implementation follows patterns from the scout server while maintaining full backward compatibility:
- All existing functionality remains unchanged
- Docsets are an optional addition
- Clean separation between Markdown and Docset storage
- Efficient SQLite-based searching

## Testing

Comprehensive test coverage has been added:
- ✅ Unit tests for DocsetService (13 tests)
- ✅ Unit tests for DocsetDatabase (20 tests)
- ✅ Integration tests for server functionality (7 tests)
- ✅ All existing tests continue to pass

## Documentation

- Updated README.md with docset configuration examples
- Created comprehensive DOCSETS.md guide with:
  - Installation instructions
  - Tool usage examples
  - Storage structure details
  - Troubleshooting guide

## Example Usage

```bash
# Configure doc-bot with docset support
{
  "mcpServers": {
    "doc-bot": {
      "command": "npx",
      "args": ["@afterxleep/doc-bot@latest", "--docs", "./docs", "--docsets", "~/MyDocSets"]
    }
  }
}
```

```javascript
// Install iOS documentation
add_docset({ source: "https://dash-docsets.com/iOS.tgz" })

// Search for UIViewController
search_docsets({ query: "UIViewController", type: "Class" })

// Unified search across all sources
search_all({ query: "authentication" })
```

## Benefits

- 📖 Access to vast library of official documentation
- 🔍 Fast SQLite-based searching
- 🎯 No manual HTML parsing required
- 🚀 Works alongside existing Markdown documentation
- 💾 Smart storage management outside git repositories

## Backward Compatibility

This PR maintains 100% backward compatibility:
- No changes to existing APIs
- No changes to existing tools
- Default behavior unchanged
- Docsets are completely optional

Ready for review\! Let me know if you need any clarification or have questions about the implementation.